### PR TITLE
Remove mention of PG 9.4 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,20 +52,10 @@ To deploy this application to a new Heroku application, use this button:
 
 [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
 
-Note that Wally requires Postgres 9.4 with JSONB support. This is only available
-in beta at Heroku right now, so after creating your application, you have to add
-a Postgres 9.4 database using the CLI:
-
-    $ heroku addons:remove heroku-postgresl:hobby-dev
-    $ heroku addons:add heroku-postgresql:hobby-dev --version=9.4
-
-Now you can actually prepare your database and start using the app:
+Note that Wally requires Postgres 9.4 with JSONB support. You can actually your
+database and start using the app:
 
     % heroku run mix ecto.migrate
-
-Of course, you could always change the app to use a `json` instead of a `jsonb`
-column, which is less performant but easier to set up, as it requires only
-Postgres 9.3.
 
 [Elixir]: http://elixir-lang.org/
 [Phoenix]: http://www.phoenixframework.org/


### PR DESCRIPTION
Since Postgres 9.4 is now the default on Heroku, there is no longer a need to mention separate instructions for using the Beta along with the Heroku deploy button.
